### PR TITLE
Add support for Parsing Strings as Dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,22 @@ Add a `"datasette-render-timestamps"` configuration block and use a `"columns"` 
 ```
 This will cause any `created` or `updated` columns in any table to be treated as timestamps and rendered.
 
-Save this to `metadata.json` and run datasette with the `--metadata` flag to load this configuration:
+Additionally, you can parse string columns as dates if you provide a `read_format` (a [strftime](http://strftime.org/) string) and name the column(s) explicitly. For example, this configuration:
+
+```json
+{
+    "plugins": {
+        "datasette-render-timestamps": {
+            "read_format": "%Y-%m-%d",
+            "columns": ["timestamp"]
+        }
+    }
+}
+```
+
+Would render `2023-03-31` in the `timestamp` column as `March 31, 2023 - 00:00:00 UTC`.
+
+Save any configuration to `metadata.json` and run datasette with the `--metadata` flag to load this configuration:
 
     datasette serve mydata.db --metadata metadata.json
 

--- a/datasette_render_timestamps/__init__.py
+++ b/datasette_render_timestamps/__init__.py
@@ -11,6 +11,7 @@ max_timestamp = int(
         (datetime.datetime.utcnow() + datetime.timedelta(days=5 * 365))
     )
 )
+# output format
 default_format = "%B %d, %Y - %H:%M:%S UTC"
 
 
@@ -24,16 +25,25 @@ def render_cell(value, column, table, database, datasette):
     )
     if "format" not in config:
         config["format"] = default_format
-    if not isinstance(value, int):
-        return None
+
     columns = config.get("columns")
-    # If explicit columns were specified, use those
-    if columns is not None:
-        if column not in columns:
+    if columns is None:
+        # autodetect recent unix timestamps
+        if isinstance(value, int) and (min_timestamp < value < max_timestamp):
+            dt = datetime.datetime.utcfromtimestamp(value)
+        else:
             return None
     else:
-        # Otherwise automatically detect timestamps
-        if not (min_timestamp < value < max_timestamp):
+        # only proceed if the column is mentioned explicitly
+        if column not in columns:
             return None
-    dt = datetime.datetime.utcfromtimestamp(value)
+
+        if isinstance(value, int):
+            dt = datetime.datetime.utcfromtimestamp(value)
+        # only parse strings with an explicit read format
+        elif isinstance(value, str) and "read_format" in config:
+            dt = datetime.datetime.strptime(value, config["read_format"])
+        else:
+            return None
+
     return dt.strftime(config["format"])

--- a/tests/test_render_timestamps.py
+++ b/tests/test_render_timestamps.py
@@ -1,8 +1,10 @@
-from unittest import mock
-from datasette.app import Datasette
-from datasette_render_timestamps import render_cell
 import datetime
+from unittest import mock
+
 import pytest
+from datasette.app import Datasette
+
+from datasette_render_timestamps import render_cell
 
 
 @pytest.fixture
@@ -28,7 +30,67 @@ def test_do_not_render_high_numbers(timestamp_within_five_years):
     )
 
 
-def test_custom_format(timestamp_within_five_years):
+def test_ignore_strings():
+    assert None == render_cell(
+        "1286720309",
+        column="timestamp",
+        table="mytable",
+        database="mydatabase",
+        datasette=Datasette([]),
+    )
+
+
+def test_ignore_string_value_without_read_format():
+    assert None == render_cell(
+        "2023-03-31",
+        column="timestamp",
+        table="mytable",
+        database="mydatabase",
+        datasette=Datasette(
+            [],
+            metadata={
+                "plugins": {"datasette-render-timestamps": {"columns": ["timestamp"]}}
+            },
+        ),
+    )
+
+
+def test_ignore_string_no_column():
+    assert None == render_cell(
+        "2023-03-31",
+        column="timestamp",
+        table="mytable",
+        database="mydatabase",
+        datasette=Datasette(
+            [],
+            metadata={
+                "plugins": {"datasette-render-timestamps": {"read_format": "%Y-%m-%d"}}
+            },
+        ),
+    )
+
+
+def test_custom_read_format():
+    assert "March 31, 2023 - 00:00:00 UTC" == render_cell(
+        "2023-03-31",
+        column="timestamp",
+        table="mytable",
+        database="mydatabase",
+        datasette=Datasette(
+            [],
+            metadata={
+                "plugins": {
+                    "datasette-render-timestamps": {
+                        "read_format": "%Y-%m-%d",
+                        "columns": "timestamp",
+                    }
+                }
+            },
+        ),
+    )
+
+
+def test_custom_write_format(timestamp_within_five_years):
     assert "{}-10-10 07:18:29".format(datetime.date.today().year) == render_cell(
         timestamp_within_five_years,
         column="timestamp",


### PR DESCRIPTION
Going through my Twitter archive, I saw they have weirdly formatted strings, like `Fri Oct 28 03:34:07 +0000 2022`. So, I added custom string parsing to this plugin.

I refactored the main function a bit for clarity when dealing with multiple data types and added docs and tests.